### PR TITLE
[FEAT] Add docker-compose.dev file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,30 @@
+version: '1.0'
+
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    volumes:
+      - ./backend:/workdir/backend
+    ports:
+      - "8000:8000"
+    networks:
+      - app-network
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    volumes:
+      - ./frontend:/workdir/frontend
+    ports:
+      - "3000:3000"
+    networks:
+      - app-network
+    depends_on:
+      - backend
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
## Overview
- 개발 환경과 배포 환경에서의 도커 컴포즈 파일을 분리하여 작성하는 것이 더 용도에 맞는 것 같아 작성했습니다.
- 배포 환경에서는 실시간으로 코드 수정 사항을 반영하지 않으니 volume을 사용할 필요가 없지만, 
개발 환경에서는 코드를 수정할 때마다 컨테이너를 다시 실행할 필요 없이 바로 테스트 하기 위해 volume을 사용하는 것이 좋을 것 같습니다.
- 또한 배포 환경에서는 이미 빌드된 이미지를 사용하는 것이 일반적이므로 도커 컴포즈 파일에 image를 사용하고, 
개발 환경에서는 코드 변경 사항에 따라 이미지를 새로 빌드해야하는 경우가 많기 때문에 build를 사용하여 Dockerfile을 기반으로 이미지를 빌드한 후 실행시킨다고 합니다.

## Change Log
- 개발 환경에서 사용하기 위해 기존 도커 컴포즈 파일에서 image 삭제, volumes 추가
- 두 개의 컨테이너가 같은 네트워크임을 명시적으로 정의

## To Reviewer
- 실행 명령어 : `docker-compose -f docker-compose.dev.yml up --build`
- (현재 이 도커 컴포즈를 실행시키기 위해서는 backend, frontend의 Dockerfile에서 WORKDIR 수정이 필요)

## Issue Tags
- Closed: #15 