### PR TITLE
[FEAT] Implement auto-send feature on Enter key press

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "next": "14.2.5",
+        "next": "^14.2.5",
         "react": "^18",
         "react-dom": "^18",
         "react-textarea-autosize": "^8.5.3"
@@ -3166,6 +3166,7 @@
       "version": "14.2.5",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.5.tgz",
       "integrity": "sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==",
+      "license": "MIT",
       "dependencies": {
         "@next/env": "14.2.5",
         "@swc/helpers": "0.5.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write ./src/**/*"
   },
   "dependencies": {
-    "next": "14.2.5",
+    "next": "^14.2.5",
     "react": "^18",
     "react-dom": "^18",
     "react-textarea-autosize": "^8.5.3"

--- a/frontend/src/app/chat/[roomId]/page.tsx
+++ b/frontend/src/app/chat/[roomId]/page.tsx
@@ -54,6 +54,13 @@ export default function ChatMessagePage() {
     setQuestion(value);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault(); 
+      handleSubmit(); 
+    }
+  };
+
   const handleSubmit = async () => {
     if (!roomId) return;
 
@@ -103,6 +110,7 @@ export default function ChatMessagePage() {
           maxRows={5}
           value={question}
           onChange={handleChange}
+          onKeyDown={handleKeyDown}
         />
         <SubmitChatButton onClick={handleSubmit}/>
       </div>


### PR DESCRIPTION
#41

## Overview
- 사용자 경험을 개선하기 위하여 채팅방에서 Enter 키만을 통해서도 메시지 입력이 가능하도록 기능 추가

## Change Log
- frontend>src>app>chat>[roomId]>page.tsx 파일의 코드 수정
- handleKeyDown 변수 추가하여, shift와 동시에 입력되지 않은 Enter 키의 경우 handleSubmit 기능으로 이어지도록 설계.

## To Reviewer
- RING-49는 지혁님과 JIRA로 만든 ISSUE KEY로 크게 신경쓰지 않으셔도 될 것 같아요.
- 처음 올려보는 코드라서, 꼭 확인해주시면 감사하겠습니다.

## Issue Tags
- Closed: #41