### PR TITLE
[FEAT] Add link_title text to URL recommendation modal

### DIFF
--- a/backend/app/routers/links.py
+++ b/backend/app/routers/links.py
@@ -14,6 +14,7 @@ router = APIRouter()
 
 class Link(BaseModel):
     url: str
+    link_title: str
     avgScore: float
     sumUsedNum: int
     sumBookmark: int
@@ -47,6 +48,7 @@ async def search_links(query: str, db: Session = Depends(get_db)):
     response = [
         Link(
             url=link.url,
+            link_title=link.link_title,
             avgScore=link.avg_score,
             sumUsedNum=link.sum_used_num,
             sumBookmark=link.sum_bookmark,

--- a/frontend/src/app/chat/@modal/(.)link-search/page.tsx
+++ b/frontend/src/app/chat/@modal/(.)link-search/page.tsx
@@ -86,13 +86,18 @@ export default function ModalPage() {
                   onChange={() => handleCheckboxChange(link.url)}
                   className="link-checkbox"
                 />
-                <a href={link.url} 
-                  target="_blank" 
-                  rel="noopener noreferrer" 
-                  className="flex"
-                >
-                  {link.url}
-                </a>
+                <div>
+                  <p className="flex">
+                    제목: {link.link_title}
+                  </p>
+                  <br></br>
+                  <a href={link.url} 
+                    target="_blank" 
+                      rel="noopener noreferrer" 
+                      className="flex">
+                      URL: {link.url}
+                  </a>
+                </div>
                 <div className="link-score-container">
                   <div className="link-score-sub-container">
                     <p>별점: {link.avgScore}</p>  

--- a/frontend/src/app/chat/link-search/page.tsx
+++ b/frontend/src/app/chat/link-search/page.tsx
@@ -86,13 +86,18 @@ export default function ModalPage() {
                   onChange={() => handleCheckboxChange(link.url)}
                   className="link-checkbox"
                 />
-                <a href={link.url} 
-                  target="_blank" 
-                  rel="noopener noreferrer" 
-                  className="flex"
-                >
-                  {link.url}
-                </a>
+                <div>
+                  <p className="flex">
+                    제목: {link.link_title}
+                  </p>
+                  <br></br>
+                  <a href={link.url} 
+                    target="_blank" 
+                      rel="noopener noreferrer" 
+                      className="flex">
+                      URL: {link.url}
+                  </a>
+                </div>
                 <div className="link-score-container">
                   <div className="link-score-sub-container">
                     <p>별점: {link.avgScore}</p>  

--- a/frontend/src/lib/interfaces.ts
+++ b/frontend/src/lib/interfaces.ts
@@ -16,6 +16,7 @@ export interface ChatMessageData {
 
 export interface LinkData {
   url: string;
+  link_title: string;
   avgScore: number;
   sumUsedNum: number;
   sumBookmark: number;


### PR DESCRIPTION
#54

## Overview
1. 링크 검색 결과에서 URL이 어떤 내용을 담고 있는지 확인 할 수 있는 제목 추가 (UI) 
2. backend에서 링크 검색 결과를 전달 시 link_title 포함해서 전달 

## Change Log
- backend/app/routers/links.py 
  - link_title 값을 전달 할 수 있도록 수정 / *2
- frontend/src/app/chat/@modal/(.)link-search/page.tsx
  - div 태그안에 url과 link_title내용을 감싸서 표현 / *1
- frontend/src/app/chat/link-search/page.tsx 
  - div 태그안에 url과 link_title내용을 감싸서 표현 / *1 
- frontend/src/lib/interfaces.ts
  - Links 테이블의 값을 전달 받는 부분에 link_title 추가 / *2 

## To Reviewer
- 디자인은 신경쓰지 않고, link_title이 표시되는 것에만 집중했습니다. 
- 구현상의 오류나 개선할 점에 있으면 조언 부탁드립니다. 

## Issue Tags
- Closed: #54