### PR TITLE
[FEAT] Implement a sorting function based on three metrics

### DIFF
--- a/frontend/src/app/chat/@modal/(.)link-search/page.tsx
+++ b/frontend/src/app/chat/@modal/(.)link-search/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { XMarkIcon } from "@/components/common/Icons";
 import InputField from "@/components/common/InputField";
@@ -15,7 +15,8 @@ export default function ModalPage() {
   const [links, setLinks] = useState<LinkData[]>([]);
   const [selectedLinks, setSelectedLinks] = useState<string[]>([]);
   const { inputLinks, addLink, limit } = useLink();
-
+  const [sortBy, setSortBy] = useState<string>('avgScore');
+    
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     setQuery(value);
@@ -51,6 +52,23 @@ export default function ModalPage() {
     router.back();
   };
 
+  const handleSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSortBy(e.target.value);
+    // 정렬 함수 호출
+    sortLinks(e.target.value);
+  };
+
+  const sortLinks = (sortBy: string) => {
+    const sortedLinks = [...links].sort((a, b) => {
+      if (sortBy === 'avgScore') return b.avgScore - a.avgScore;
+      if (sortBy === 'sumUsedNum') return b.sumUsedNum - a.sumUsedNum;
+      if (sortBy === 'sumBookmark') return b.sumBookmark - a.sumBookmark;
+      return 0;
+    });
+    setLinks(sortedLinks);
+  };
+
+
   return (
     <div className="modal-container">
       <div className="modal-sub-container">
@@ -71,10 +89,10 @@ export default function ModalPage() {
             <LinkSearchButton onClick={handleSubmit} />
           </div>
           <div className="select-container">
-            <select className="select">
-              <option value="">별점 높은 순</option>
-              <option value="option1">첨부 많은 순</option>
-              <option value="option2">저장 많은 순</option>
+            <select className="select" onChange={handleSortChange} value={sortBy}>
+              <option value="avgScore">별점 높은 순</option>
+              <option value="sumUsedNum">첨부 많은 순</option>
+              <option value="sumBookmark">저장 많은 순</option>
             </select>
           </div>
           <div className="link-list-container">

--- a/frontend/src/app/chat/link-search/page.tsx
+++ b/frontend/src/app/chat/link-search/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { XMarkIcon } from "@/components/common/Icons";
 import InputField from "@/components/common/InputField";
@@ -15,6 +15,7 @@ export default function ModalPage() {
   const [links, setLinks] = useState<LinkData[]>([]);
   const [selectedLinks, setSelectedLinks] = useState<string[]>([]);
   const { inputLinks, addLink, limit } = useLink();
+  const [sortBy, setSortBy] = useState<string>('avgScore');
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
@@ -51,6 +52,22 @@ export default function ModalPage() {
     router.back();
   };
 
+  const handleSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSortBy(e.target.value);
+    // 정렬 함수 호출
+    sortLinks(e.target.value);
+  };
+
+  const sortLinks = (sortBy: string) => {
+    const sortedLinks = [...links].sort((a, b) => {
+      if (sortBy === 'avgScore') return b.avgScore - a.avgScore;
+      if (sortBy === 'sumUsedNum') return b.sumUsedNum - a.sumUsedNum;
+      if (sortBy === 'sumBookmark') return b.sumBookmark - a.sumBookmark;
+      return 0;
+    });
+    setLinks(sortedLinks);
+  };
+
   return (
     <div className="modal-container">
       <div className="modal-sub-container">
@@ -71,10 +88,10 @@ export default function ModalPage() {
             <LinkSearchButton onClick={handleSubmit} />
           </div>
           <div className="select-container">
-            <select className="select">
-              <option value="">별점 높은 순</option>
-              <option value="option1">첨부 많은 순</option>
-              <option value="option2">저장 많은 순</option>
+            <select className="select" onChange={handleSortChange} value={sortBy}>
+              <option value="avgScore">별점 높은 순</option>
+              <option value="sumUsedNum">첨부 많은 순</option>
+              <option value="sumBookmark">저장 많은 순</option>
             </select>
           </div>
           <div className="link-list-container">


### PR DESCRIPTION
## Overview
1. 세 가지 지표(별점, 첨부 수, 북마크 수)를 기준으로 내림차순, 오름차순 정렬이 가능하도록 구현. 

## Change Log
- frontend/src/app/chat/@modal/(.)link-search/page.tsx 
   - handleSortChange, sortLinks / 이벤트 헨들러, sort 함수를 활용하여 정렬 기능 추가 / *1
- frontend/src/app/chat/link-search/page.tsx
   - handleSortChange, sortLinks / 이벤트 헨들러, sort 함수를 활용하여 정렬 기능 추가 / *1
## To Reviewer
- 처음 링크 검색 결과는 내부적으로 유사도가 높은 것을 기준으로 정렬됩니다. 
- 사용자 입장에서 검색된 링크 리스트를 볼때 내부적으로 유사도에 의해 정렬되었단 사실을 알지 못하기 때문에 처음에는 유사도 기반으로 검색되었음을 표시해야 할지, 세 가지 지표 처럼 유사도를 기반으로 정렬하는 기능을 추가해야 할지 고민입니다. 
- 위 고민 사항들을 제외하고는 각각 지표별로 정상적으로 정렬되었음을 확인하였습니다. 
- 기술적인 부분 보다는 사용자 입장에서 어떻게 보였으면 좋을지 의논해보았으면 좋겠습니다.

## Issue Tags
- Closed: #57